### PR TITLE
Backward compatibility

### DIFF
--- a/unpack.js
+++ b/unpack.js
@@ -40,7 +40,7 @@ const initProps = (props) => {
                     propObj.doCompress = Number(props[idx]);
                     break;
             }
-        } catch {
+        } catch (e) {
             throw new Error(
                 `Error while parsing the binary props! ${READ_ERR}\nParsing ${prop} at index ${idx}`
             );
@@ -60,7 +60,7 @@ let rawProps = binary.match(/\{.*}\n,\n".*"\n,\n\{.*}\n,\n\{.*}\n,\n([012])/g);
 
 try {
     rawProps = rawProps[0].split("\n,\n");
-} catch {
+} catch (e) {
     throw new Error(`Error while reading the binary props! ${READ_ERR}`);
 }
 
@@ -240,7 +240,7 @@ const getFile = (fd, [startPos, size]) => {
     try {
         if (DOCOMPRESS === GZIP) code = gunzipSync(code);
         else if (DOCOMPRESS === BROTLI) code = brotliDecompressSync(code);
-    } catch {}
+    } catch (e) {}
 
     return code;
 };

--- a/unpack.js
+++ b/unpack.js
@@ -56,7 +56,7 @@ if (!argv.i || !argv.o)
     throw new Error("You need to provide an input file and an output directory!");
 
 const binary = fs.readFileSync(argv.i, { encoding: "utf-8" });
-let rawProps = binary.match(/\{.*\}\n,\n".*"\n,\n\{.*\}\n,\n\{.*\}\n,\n(0|1|2)/g);
+let rawProps = binary.match(/\{.*}\n,\n".*"\n,\n\{.*}\n,\n\{.*}\n,\n([012])/g);
 
 try {
     rawProps = rawProps[0].split("\n,\n");
@@ -107,11 +107,11 @@ const uppercaseDriveLetter = (f) => {
 
 const removeTrailingSlashes = (f) => {
     if (f === "/") {
-        return f; // dont remove from "/"
+        return f; // don't remove from "/"
     }
 
     if (f.slice(1) === ":\\") {
-        return f; // dont remove from "D:\"
+        return f; // don't remove from "D:\"
     }
 
     let last = f.length - 1;
@@ -277,6 +277,8 @@ const executeFile = (blob) => {
             `Error while executing the code! Got the following error:\n${e.toString()}`
         );
     }
+
+    return true;
 };
 
 let exec = false;
@@ -291,10 +293,9 @@ for (let path in VIRTUAL_FILESYSTEM) {
     if (DOCOMPRESS) path = toOriginal(reverseLinks(path));
 
     const vfs = findVirtualFileSystemEntry(path);
-    let blob;
 
     if (vfs[STORE_BLOB] || vfs[STORE_CONTENT]) {
-        blob = getFile(fd, vfs[STORE_CONTENT] || vfs[STORE_BLOB]);
+        let blob = getFile(fd, vfs[STORE_CONTENT] || vfs[STORE_BLOB]);
 
         if (argv.run && path === props.entryPoint) {
             exec = executeFile(blob);

--- a/unpack.js
+++ b/unpack.js
@@ -25,7 +25,7 @@ const initProps = (props) => {
                     break;
                 case 1:
                     prop = "entryPoint";
-                    propObj.entryPoint = props[idx].replaceAll(`"`, "");
+                    propObj.entryPoint = props[idx].replace(/"/g, "");
                     break;
                 case 2:
                     prop = "symlinks";

--- a/unpack.js
+++ b/unpack.js
@@ -56,7 +56,7 @@ if (!argv.i || !argv.o)
     throw new Error("You need to provide an input file and an output directory!");
 
 const binary = fs.readFileSync(argv.i, { encoding: "utf-8" });
-let rawProps = binary.match(/\{.*}\n,\n".*"\n,\n\{.*}\n,\n\{.*}\n,\n([012])/g);
+let rawProps = binary.match(/\{.*}\n,\n".*"/g);
 
 try {
     rawProps = rawProps[0].split("\n,\n");

--- a/unpack.js
+++ b/unpack.js
@@ -245,12 +245,29 @@ const getFile = (fd, [startPos, size]) => {
     return code;
 };
 
+const mkdirRecursiveSync = (targetDir) => {
+  const sep = path.sep; // path separator (usually '\' on Windows and '/' on Linux)
+  const initDir = path.isAbsolute(targetDir) ? sep : ''; // if the path is absolute, start from root, else empty string
+  const baseDir = '.';
+
+  // Split the path and reduce through it, creating one directory at a time
+  targetDir.split(sep).reduce((parentDir, childDir) => {
+    const currentDir = path.resolve(parentDir, childDir);
+
+    if (!fs.existsSync(currentDir)) {
+      fs.mkdirSync(currentDir);
+    }
+
+    return currentDir;
+  }, initDir || baseDir);
+}
+
 const writeFile = (vfsPath, outputPath, blob) => {
     if (vfsPath.startsWith("C:")) vfsPath = vfsPath.replace("C:", "");
 
     outputPath = path.join(path.resolve(outputPath), vfsPath);
 
-    if (!fs.existsSync(outputPath)) fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    if (!fs.existsSync(outputPath)) mkdirRecursiveSync(path.dirname(outputPath));
 
     fs.writeFileSync(outputPath, blob);
 };


### PR DESCRIPTION
As [this commit shows](https://github.com/vercel/pkg/commit/cd5ce74ec181d0f6cd7ae0b218658b6c449e5655#diff-13a03183363500e847cfa8db282da17f8941ffff821d5ec37e8f18582a1893e3L168), packers of former versions of vercel/pkg don't contain fields like %DOCOMPRESS%.


TBH, this patchset is only for doing my shit, but it might be helpful if someone is unpacking an older version of vercel/pkg.